### PR TITLE
Updated parseValidResponse

### DIFF
--- a/item/grease-script.js
+++ b/item/grease-script.js
@@ -301,12 +301,12 @@ function parseValidResponse(response) {
 	
 	// add tomato-meter score and icon
 	var tomatoMeterScoreImage = '';
-	if (response.tomatoMeter == 'N/A') {
+	if (response.Ratings[1].Value == 'N/A') {
 		tomatoMeterScoreText = 'No Score Yet...';
 		tomatoMeterScoreClass = ' noScore';
 	} else {
 		tomatoMeterScoreClass = '';
-		tomatoMeterScoreText = response.tomatoMeter + '%';
+		tomatoMeterScoreText = response.Ratings[1].Value;
 
 		tomatoMeterScoreImage = $('<div/>').
 			attr('class', 'rtIcon ' + response.tomatoImage).


### PR DESCRIPTION
This fixes the problem with not retrieving and displaying the overall
Rotten Tomatoes Score. It does not fix the abscence of other previously
used fields that OMDB API JSON no longer seems to return anything but
"N/A" for.